### PR TITLE
posts: fix svg of the migration project post

### DIFF
--- a/content/post/kick-off-du-projet-de-migration-rero-ils.de.md
+++ b/content/post/kick-off-du-projet-de-migration-rero-ils.de.md
@@ -42,5 +42,5 @@ Der Migrationszeitplan (siehe unten) hat 4 wichtige Meilensteine:
 * `Ende April`: 2. vollständiges Laden der Daten
 * `12. Juli 2021`: Go-Live
 
-{{< figure src="/img/calendrier_migration.svg" caption="Migrationszeitplan (auf Französisch)" alt="Migrationszeitplan (auf Französisch)" link="/img/calendrier_migration.svg" target="_blank" >}}
+{{< figure src="/img/calendrier_migration.svg" caption="Migrationszeitplan (auf Französisch)" alt="Migrationszeitplan (auf Französisch)" link="/img/calendrier_migration.svg" >}}
 

--- a/content/post/kick-off-du-projet-de-migration-rero-ils.md
+++ b/content/post/kick-off-du-projet-de-migration-rero-ils.md
@@ -42,4 +42,4 @@ Le calendrier de migration (voir ci-dessous) comporte 4 jalons importants:
 * `fin avril`: 2e chargement complet
 * `12 juillet 2021`: go-live
 
-{{< figure src="/img/calendrier_migration.svg" caption="Calendrier de migration" alt="Calendrier de migration" link="/img/calendrier_migration.svg" target="_blank" >}}
+{{< figure src="/img/calendrier_migration.svg" caption="Calendrier de migration" alt="Calendrier de migration" link="/img/calendrier_migration.svg" >}}

--- a/static/img/calendrier_migration.svg
+++ b/static/img/calendrier_migration.svg
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg version="1.2" width="255.31mm" height="104.33mm" viewBox="2000 1996 25531 10433" preserveAspectRatio="xMidYMid" fill-rule="evenodd" stroke-width="28.222" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" xmlns:ooo="http://xml.openoffice.org/svg/export" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:presentation="http://sun.com/xmlns/staroffice/presentation" xmlns:smil="http://www.w3.org/2001/SMIL20/" xmlns:anim="urn:oasis:names:tc:opendocument:xmlns:animation:1.0" xml:space="preserve">
+<svg version="1.2" width="100%" height="100%" viewBox="2000 1996 25531 10433" preserveAspectRatio="xMidYMid" fill-rule="evenodd" stroke-width="28.222" stroke-linejoin="round" xmlns="http://www.w3.org/2000/svg" xmlns:ooo="http://xml.openoffice.org/svg/export" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:presentation="http://sun.com/xmlns/staroffice/presentation" xmlns:smil="http://www.w3.org/2001/SMIL20/" xmlns:anim="urn:oasis:names:tc:opendocument:xmlns:animation:1.0" xml:space="preserve">
  <defs>
   <font id="EmbeddedFont_1" horiz-adv-x="2048">
    <font-face font-family="Arial embedded" units-per-em="2048" font-weight="normal" font-style="normal" ascent="1845" descent="438"/>


### PR DESCRIPTION
* Allows to open the migration SVG in the same tab.
* Expands the SVG to the entire viewport.

Co-Authored-by: Igor Milhit <igor.milhit@rero.ch>
